### PR TITLE
requirements.txt 파일 이름 & 내용 수정

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 PyGithub==1.28
-configparser=3.5.0
+configparser==3.5.0
 python-telegram-bot==5.0.0


### PR DESCRIPTION
이번에 텔레그램 봇 만들어보려고 참고하다가 (아주아주 사소한 오류발견해서) PR 남깁니다!

1. 파일 이름이 README와 달라 이름 수정했고,
2. 해당파일의 2번째 줄에서 '=' 연산자 하나가 빠져있어서 추가했습니다.
